### PR TITLE
CPU usage after close PC

### DIFF
--- a/fancywebrtc/src/main/java/co/fitcom/fancywebrtc/FancyRTCMediaDevices.java
+++ b/fancywebrtc/src/main/java/co/fitcom/fancywebrtc/FancyRTCMediaDevices.java
@@ -69,6 +69,13 @@ public class FancyRTCMediaDevices {
         }
     }
 
+    public static void stopCapturers() {
+        for (FancyCapturer entry : videoTrackcapturerMap.values()) {
+            entry.getCapturer().dispose();
+        }
+        videoTrackcapturerMap.clear();
+    }
+
     public static void getUserMedia(Context context, FancyRTCMediaStreamConstraints constraints, GetUserMediaListener listener) {
         FancyRTCPeerConnection.executor.execute(() -> {
             String streamId = FancyUtils.getUUID();


### PR DESCRIPTION
I notice that process "android.hardware.camera.provider" steel consume about 25% of CPU after PC was closed because capturer was not stopped.
It should be stopped when we stop publishing or when we stop the stream(only cam, not PC).
I give a sample solution.